### PR TITLE
Update cargo make subcommand test

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,8 +28,7 @@ test:
     - test -f $PREFIX/bin/makers  # [unix]
     - if not exist %PREFIX%\bin\cargo-make.exe exit 1  # [win]
     - if not exist %PREFIX%\bin\makers.exe exit 1  # [win]
-    # cargo-make does no longer seem to be standalone, but a plugin for cargo: cargo-make --help no longer works
-    # - cargo_make --help
+    - cargo-make make --help
     - makers -h
 
 about:


### PR DESCRIPTION
Didn't test but its related to sagiegurari/cargo-make#1119
it should be a subcommand and not sure how it worked before.
another strange thing (help me understand that please) is that you had cargo_make instead of cargo-make. is that ok?